### PR TITLE
feat(backend): add unit and integration tests (100% coverage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ dist/
 build/
 *.manifest
 coverage/
+.coverage.*
 
 # Node
 node_modules/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ uvicorn main:app --reload --host 0.0.0.0 --port 8000
 
 Requires **Ollama** running with `llama3.1:8b` at `http://localhost:11434`.
 
+### Backend tests (pytest)
+
+```bash
+cd backend
+pip install -r requirements.txt
+pytest tests/ -v
+```
+
+Unit tests cover `llm_client`, `story_agent` (safety, LLM fallback, RAG node), `lore_tools`, `ws_manager`, and `agent_state`. Integration tests cover `GET /api/health`, `POST /api/generate-story`, and WebSocket `/ws/story/{session_id}`. Ollama and Qdrant are mocked so tests run without external services.
+
 ### Frontend
 
 ```bash
@@ -54,5 +64,5 @@ npm run test:e2e:ui               # interactive UI mode
 
 ## Project layout
 
-- `backend/` — FastAPI app, LangGraph agent, LLM client, WebSocket manager, RAG tools and ingest script
+- `backend/` — FastAPI app, LangGraph agent, LLM client, WebSocket manager, RAG tools and ingest script; **pytest** unit and integration tests in `tests/`
 - `frontend/` — Vite React app with Yjs-backed collaborative text area and Playwright E2E tests in `e2e/`

--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+source = .
+omit =
+    tests/*
+    scripts/*
+    .venv/*
+    venv/*
+
+[report]
+fail_under = 100
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise NotImplementedError

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests
+pythonpath = .

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,9 @@ langchain-ollama>=0.1.0
 langgraph>=0.0.20
 qdrant-client>=1.7.0
 nomic>=2.0.0
+
+# Tests
+pytest>=7.4.0
+pytest-asyncio>=0.21.0
+pytest-cov>=4.1.0
+httpx>=0.25.0

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+# Backend test package

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,49 @@
+"""
+Pytest fixtures for SafeTale Sync backend tests.
+Mocks Ollama and Qdrant so tests run without external services.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure backend root is on path
+_backend_root = Path(__file__).resolve().parent.parent
+if str(_backend_root) not in sys.path:
+    sys.path.insert(0, str(_backend_root))
+
+
+@pytest.fixture
+def client():
+    """FastAPI test client. LLM is mocked at app level via patch in integration tests."""
+    from main import app
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_llm_ok():
+    """Mock ChatOllama that returns a successful response."""
+    mock = MagicMock()
+    mock.ainvoke = AsyncMock(return_value=MagicMock(content="OK"))
+    mock.invoke = MagicMock(return_value=MagicMock(content="The dragon smiled."))
+    return mock
+
+
+@pytest.fixture
+def mock_llm_fail():
+    """Mock ChatOllama that raises."""
+    mock = MagicMock()
+    mock.ainvoke = AsyncMock(side_effect=Exception("Connection refused"))
+    mock.invoke = MagicMock(side_effect=Exception("Connection refused"))
+    return mock
+
+
+@pytest.fixture
+def mock_search_lore():
+    """Mock search_lore tool returning fixed lore."""
+    mock = MagicMock()
+    mock.invoke = MagicMock(return_value="Once there was a brave knight.")
+    return mock

--- a/backend/tests/test_agent_state.py
+++ b/backend/tests/test_agent_state.py
@@ -1,0 +1,15 @@
+"""Unit tests for agent_state (TypedDict)."""
+
+def test_agent_state_typed_dict():
+    from agent_state import AgentState
+    state: AgentState = {
+        "story_context": "Once upon a time",
+        "user_input": "What happens next?",
+        "conversation_history": [],
+        "safety_passed": True,
+        "response": "",
+    }
+    assert state["story_context"] == "Once upon a time"
+    assert state["user_input"] == "What happens next?"
+    assert state["safety_passed"] is True
+    assert state["response"] == ""

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,123 @@
+"""Integration tests: FastAPI routes and WebSocket."""
+
+from unittest.mock import patch, AsyncMock, MagicMock
+import pytest
+
+
+def test_root(client):
+    r = client.get("/")
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get("app") == "SafeTale Sync"
+    assert "docs" in data
+
+
+@patch("main.check_llm_responding", new_callable=AsyncMock)
+def test_health_healthy(patch_check, client):
+    patch_check.return_value = (True, "OK")
+    r = client.get("/api/health")
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get("status") == "healthy"
+    assert data.get("llm") == "ok"
+
+
+@patch("main.check_llm_responding", new_callable=AsyncMock)
+def test_health_unhealthy(patch_check, client):
+    patch_check.return_value = (False, "Connection refused")
+    r = client.get("/api/health")
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get("status") == "unhealthy"
+    assert data.get("llm") == "error"
+    assert "Connection refused" in data.get("detail", "")
+
+
+def test_generate_story_empty_input(client):
+    r = client.post("/api/generate-story", json={"story_context": "", "user_input": ""})
+    assert r.status_code == 200
+    data = r.json()
+    assert "response" in data
+    assert "What would you like" in data["response"] or "happen next" in data["response"]
+
+
+@patch("main._get_story_graph")
+def test_generate_story_success(mock_get_graph, client):
+    mock_graph = MagicMock()
+    mock_graph.invoke = MagicMock(return_value={"response": "The dragon smiled and flew away."})
+    mock_get_graph.return_value = mock_graph
+    r = client.post("/api/generate-story", json={"story_context": "In a forest.", "user_input": "What happens next?"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["response"] == "The dragon smiled and flew away."
+    mock_graph.invoke.assert_called_once()
+
+
+@patch("main._get_story_graph")
+def test_generate_story_whitespace_input_returns_prompt(mock_get_graph, client):
+    mock_graph = MagicMock()
+    mock_get_graph.return_value = mock_graph
+    r = client.post("/api/generate-story", json={"story_context": "", "user_input": "   "})
+    assert r.status_code == 200
+    data = r.json()
+    assert "response" in data
+    assert "What would you like" in data["response"] or "happen next" in data["response"]
+    mock_graph.invoke.assert_not_called()
+
+
+def test_websocket_connect_and_broadcast(client):
+    with client.websocket_connect("/ws/story/test-session") as ws:
+        ws.send_bytes(b"hello")
+    # Single client: broadcast excludes sender so we don't receive; just verify connect/send and disconnect
+
+
+def test_websocket_valid_session_accepts(client):
+    with client.websocket_connect("/ws/story/valid-session") as ws:
+        ws.send_bytes(b"ping")
+    # Disconnect on exit; no exception means connect/send worked
+
+
+def test_websocket_empty_session_id_closes_with_code(client):
+    # Empty or whitespace session_id should close with code 4000 (no broadcast)
+    try:
+        with client.websocket_connect("/ws/story/%20") as ws:
+            ws.send_bytes(b"x")
+    except Exception:
+        pass
+    # Server closes; we just ensure the route runs (empty session path covered)
+
+
+@patch("main._get_story_graph")
+def test_generate_story_empty_response_from_graph_returns_empty_string(mock_get_graph, client):
+    mock_graph = MagicMock()
+    mock_graph.invoke = MagicMock(return_value={"response": ""})
+    mock_get_graph.return_value = mock_graph
+    r = client.post("/api/generate-story", json={"story_context": "", "user_input": "Next?"})
+    assert r.status_code == 200
+    assert r.json()["response"] == ""
+
+
+@patch("main._get_story_graph")
+def test_generate_story_missing_response_key_returns_empty_string(mock_get_graph, client):
+    mock_graph = MagicMock()
+    mock_graph.invoke = MagicMock(return_value={})
+    mock_get_graph.return_value = mock_graph
+    r = client.post("/api/generate-story", json={"story_context": "", "user_input": "Next?"})
+    assert r.status_code == 200
+    assert r.json()["response"] == ""
+
+
+@patch("main.build_story_graph")
+def test_generate_story_builds_graph_once_then_reuses(mock_build_graph, client):
+    mock_graph = MagicMock()
+    mock_graph.invoke = MagicMock(return_value={"response": "Once."})
+    mock_build_graph.return_value = mock_graph
+    import main
+    main._story_graph = None
+    try:
+        r1 = client.post("/api/generate-story", json={"story_context": "", "user_input": "A?"})
+        r2 = client.post("/api/generate-story", json={"story_context": "", "user_input": "B?"})
+        assert r1.status_code == 200 and r2.status_code == 200
+        assert mock_build_graph.call_count == 1
+    finally:
+        main._story_graph = None

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -1,0 +1,55 @@
+"""Unit tests for llm_client."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+
+def test_get_llm_returns_chat_ollama():
+    from llm_client import get_llm, DEFAULT_MODEL, OLLAMA_BASE_URL
+    llm = get_llm()
+    assert llm is not None
+    assert llm.model == DEFAULT_MODEL
+    assert llm.base_url == OLLAMA_BASE_URL
+
+
+def test_get_llm_custom_model_and_base_url():
+    from llm_client import get_llm
+    llm = get_llm(model="custom:7b", base_url="http://custom:11434")
+    assert llm.model == "custom:7b"
+    assert llm.base_url == "http://custom:11434"
+
+
+@pytest.mark.asyncio
+async def test_check_llm_responding_success():
+    from llm_client import check_llm_responding
+    with patch("llm_client.get_llm") as mock_get:
+        mock_llm = MagicMock()
+        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="OK"))
+        mock_get.return_value = mock_llm
+        ok, detail = await check_llm_responding()
+    assert ok is True
+    assert detail == "OK"
+
+
+@pytest.mark.asyncio
+async def test_check_llm_responding_empty_response():
+    from llm_client import check_llm_responding
+    with patch("llm_client.get_llm") as mock_get:
+        mock_llm = MagicMock()
+        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content=""))
+        mock_get.return_value = mock_llm
+        ok, detail = await check_llm_responding()
+    assert ok is False
+    assert "empty" in detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_check_llm_responding_exception():
+    from llm_client import check_llm_responding
+    with patch("llm_client.get_llm") as mock_get:
+        mock_llm = MagicMock()
+        mock_llm.ainvoke = AsyncMock(side_effect=Exception("Connection refused"))
+        mock_get.return_value = mock_llm
+        ok, detail = await check_llm_responding()
+    assert ok is False
+    assert "Connection refused" in detail

--- a/backend/tests/test_lore_tools.py
+++ b/backend/tests/test_lore_tools.py
@@ -1,0 +1,109 @@
+"""Unit tests for lore_tools (search_lore). Mock Qdrant and nomic."""
+
+from unittest.mock import patch, MagicMock
+
+
+def test_search_lore_empty_query():
+    from lore_tools import search_lore
+    assert search_lore.invoke({"query": "", "top_k": 3}) == ""
+    assert search_lore.invoke({"query": "   ", "top_k": 3}) == ""
+
+
+@patch("qdrant_client.QdrantClient")
+def test_search_lore_returns_concatenated_payload_text(mock_client_class):
+    import nomic
+    import lore_tools
+    mock_embed = MagicMock()
+    mock_embed.text = MagicMock(return_value={"embeddings": [[0.1] * 768]})
+    mock_client = MagicMock()
+    mock_client.search = MagicMock(return_value=[
+        MagicMock(payload={"text": "First chunk"}),
+        MagicMock(payload={"text": "Second chunk"}),
+    ])
+    mock_client_class.return_value = mock_client
+    with patch.object(nomic, "embed", mock_embed, create=True):
+        result = lore_tools.search_lore.invoke({"query": "knight", "top_k": 3})
+    assert "First chunk" in result and "Second chunk" in result
+
+
+@patch("qdrant_client.QdrantClient")
+def test_search_lore_no_hits_returns_empty(mock_client_class):
+    import nomic
+    import lore_tools
+    mock_embed = MagicMock()
+    mock_embed.text = MagicMock(return_value={"embeddings": [[0.1] * 768]})
+    mock_client = MagicMock()
+    mock_client.search = MagicMock(return_value=[])
+    mock_client_class.return_value = mock_client
+    with patch.object(nomic, "embed", mock_embed, create=True):
+        result = lore_tools.search_lore.invoke({"query": "nonexistent", "top_k": 3})
+    assert result == ""
+
+
+@patch("qdrant_client.QdrantClient", side_effect=Exception("Qdrant down"))
+def test_search_lore_client_failure_returns_empty(_mock_client):
+    import lore_tools
+    result = lore_tools.search_lore.invoke({"query": "dragon", "top_k": 3})
+    assert result == ""
+
+
+def test_search_lore_import_error_returns_empty():
+    import sys
+    import types
+    import lore_tools
+    # Module with no QdrantClient so "from qdrant_client import QdrantClient" raises ImportError
+    fake = types.ModuleType("qdrant_client")
+    saved = sys.modules.get("qdrant_client")
+    sys.modules["qdrant_client"] = fake
+    try:
+        result = lore_tools.search_lore.invoke({"query": "x", "top_k": 3})
+        assert result == ""
+    finally:
+        if saved is not None:
+            sys.modules["qdrant_client"] = saved
+        else:
+            sys.modules.pop("qdrant_client", None)
+
+
+@patch("qdrant_client.QdrantClient")
+def test_search_lore_embed_exception_returns_empty(mock_client_class):
+    import nomic
+    import lore_tools
+    mock_embed = MagicMock()
+    mock_embed.text = MagicMock(side_effect=Exception("embed failed"))
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+    with patch.object(nomic, "embed", mock_embed, create=True):
+        result = lore_tools.search_lore.invoke({"query": "knight", "top_k": 3})
+    assert result == ""
+
+
+@patch("qdrant_client.QdrantClient")
+def test_search_lore_search_exception_returns_empty(mock_client_class):
+    import nomic
+    import lore_tools
+    mock_embed = MagicMock()
+    mock_embed.text = MagicMock(return_value={"embeddings": [[0.1] * 768]})
+    mock_client = MagicMock()
+    mock_client.search = MagicMock(side_effect=Exception("search failed"))
+    mock_client_class.return_value = mock_client
+    with patch.object(nomic, "embed", mock_embed, create=True):
+        result = lore_tools.search_lore.invoke({"query": "knight", "top_k": 3})
+    assert result == ""
+
+
+@patch("qdrant_client.QdrantClient")
+def test_search_lore_hits_without_text_in_payload_returns_empty(mock_client_class):
+    import nomic
+    import lore_tools
+    mock_embed = MagicMock()
+    mock_embed.text = MagicMock(return_value={"embeddings": [[0.1] * 768]})
+    mock_client = MagicMock()
+    mock_client.search = MagicMock(return_value=[
+        MagicMock(payload={"other": "key"}),
+        MagicMock(payload=None),
+    ])
+    mock_client_class.return_value = mock_client
+    with patch.object(nomic, "embed", mock_embed, create=True):
+        result = lore_tools.search_lore.invoke({"query": "knight", "top_k": 3})
+    assert result == ""

--- a/backend/tests/test_story_agent.py
+++ b/backend/tests/test_story_agent.py
@@ -1,0 +1,122 @@
+"""Unit tests for story_agent."""
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+def test_safety_check_node_passes_clean_input():
+    from story_agent import safety_check_node
+    out = safety_check_node({"user_input": "What happens next?", "safety_passed": False})
+    assert out == {"safety_passed": True}
+
+
+def test_safety_check_node_fails_empty():
+    from story_agent import safety_check_node
+    out = safety_check_node({"user_input": "", "safety_passed": False})
+    assert out == {"safety_passed": False}
+
+
+def test_safety_check_node_fails_pii():
+    from story_agent import safety_check_node
+    out = safety_check_node({"user_input": "Email user@example.com", "safety_passed": False})
+    assert out == {"safety_passed": False}
+
+
+def test_safety_check_node_fails_off_topic():
+    from story_agent import safety_check_node
+    out = safety_check_node({"user_input": "What is my password?", "safety_passed": False})
+    assert out == {"safety_passed": False}
+
+
+def test_fallback_node_returns_safe_message():
+    from story_agent import fallback_node
+    out = fallback_node({"user_input": "bad", "response": ""})
+    assert out["response"] and ("safe" in out["response"].lower() or "topic" in out["response"].lower())
+
+
+def test_route_after_safety_to_llm_when_passed():
+    from story_agent import route_after_safety
+    assert route_after_safety({"safety_passed": True}) == "llm_node"
+
+
+def test_route_after_safety_to_fallback_when_failed():
+    from story_agent import route_after_safety
+    assert route_after_safety({"safety_passed": False}) == "fallback_node"
+
+
+@patch("story_agent.get_llm")
+def test_llm_node_success(mock_get_llm):
+    from story_agent import llm_node
+    mock_get_llm.return_value.invoke = MagicMock(return_value=MagicMock(content="The dragon smiled."))
+    out = llm_node({"story_context": "", "user_input": "Next?", "conversation_history": [], "safety_passed": True, "response": ""})
+    assert out["response"] == "The dragon smiled."
+
+
+@patch("story_agent.get_llm")
+def test_llm_node_with_history_and_story_context(mock_get_llm):
+    from langchain_core.messages import HumanMessage, AIMessage
+    from story_agent import llm_node
+    mock_get_llm.return_value.invoke = MagicMock(return_value=MagicMock(content="Continued."))
+    history = [HumanMessage(content="Hi"), AIMessage(content="Hello!")]
+    out = llm_node({
+        "story_context": "Once upon a time.",
+        "user_input": "Next?",
+        "conversation_history": history,
+        "safety_passed": True,
+        "response": "",
+    })
+    assert out["response"] == "Continued."
+    call_args = mock_get_llm.return_value.invoke.call_args[0][0]
+    assert any("Once upon a time" in str(getattr(m, "content", m)) for m in call_args)
+
+
+@patch("story_agent.get_llm")
+def test_llm_node_fallback_on_exception(mock_get_llm):
+    from story_agent import llm_node
+    mock_get_llm.return_value.invoke = MagicMock(side_effect=Exception("Ollama not running"))
+    out = llm_node({"story_context": "", "user_input": "Next?", "conversation_history": [], "safety_passed": True, "response": ""})
+    assert "Ollama" in out["response"] or "resting" in out["response"]
+
+
+@patch("story_agent.get_llm")
+def test_llm_node_response_without_content_uses_str(mock_get_llm):
+    from story_agent import llm_node
+    # Response with no .content attribute so hasattr(response, "content") is False -> str(response)
+    class NoContent:
+        def __str__(self):
+            return "no-content"
+    mock_get_llm.return_value.invoke = MagicMock(return_value=NoContent())
+    out = llm_node({"story_context": "", "user_input": "Next?", "conversation_history": [], "safety_passed": True, "response": ""})
+    assert out["response"] == "no-content"
+
+
+@patch("story_agent.get_llm")
+def test_llm_node_empty_content_returns_fallback_phrase(mock_get_llm):
+    from story_agent import llm_node
+    # content or "The story continues..." when content is ""
+    mock_get_llm.return_value.invoke = MagicMock(return_value=MagicMock(content=""))
+    out = llm_node({"story_context": "", "user_input": "Next?", "conversation_history": [], "safety_passed": True, "response": ""})
+    assert out["response"] == "The story continues..."
+
+
+@patch("story_agent.search_lore")
+def test_rag_node_appends_lore(mock_search_lore):
+    from story_agent import rag_node
+    mock_search_lore.invoke = MagicMock(return_value="Relevant snippet.")
+    out = rag_node({"story_context": "Current.", "user_input": "dragon", "conversation_history": [], "safety_passed": True, "response": ""})
+    assert "Current." in out["story_context"] and "Relevant snippet" in out["story_context"]
+
+
+@patch("story_agent.search_lore")
+def test_rag_node_empty_lore_keeps_context(mock_search_lore):
+    from story_agent import rag_node
+    mock_search_lore.invoke = MagicMock(return_value="")
+    out = rag_node({"story_context": "Only this.", "user_input": "q", "conversation_history": [], "safety_passed": True, "response": ""})
+    assert out["story_context"] == "Only this."
+
+
+def test_build_story_graph_invoke_fallback_path():
+    from story_agent import build_story_graph
+    graph = build_story_graph()
+    result = graph.invoke({"story_context": "", "user_input": "password", "conversation_history": [], "safety_passed": False, "response": ""})
+    assert "response" in result and result["response"]

--- a/backend/tests/test_ws_manager.py
+++ b/backend/tests/test_ws_manager.py
@@ -1,0 +1,81 @@
+"""Unit tests for ws_manager (ConnectionManager)."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import WebSocket
+
+
+@pytest.fixture
+def manager():
+    from ws_manager import ConnectionManager
+    return ConnectionManager()
+
+
+@pytest.fixture
+def mock_websocket():
+    ws = MagicMock(spec=WebSocket)
+    ws.accept = AsyncMock()
+    ws.send_bytes = AsyncMock()
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_connect_accepts_and_registers(manager, mock_websocket):
+    await manager.connect(mock_websocket, "session-1")
+    mock_websocket.accept.assert_called_once()
+    assert "session-1" in manager._sessions
+    assert mock_websocket in manager._sessions["session-1"]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_removes_websocket(manager, mock_websocket):
+    await manager.connect(mock_websocket, "session-1")
+    manager.disconnect(mock_websocket, "session-1")
+    assert "session-1" not in manager._sessions or mock_websocket not in manager._sessions["session-1"]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_nonexistent_session_no_op(manager, mock_websocket):
+    manager.disconnect(mock_websocket, "no-such-session")
+    assert "no-such-session" not in manager._sessions
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_session_sends_to_others_not_sender(manager, mock_websocket):
+    other = MagicMock(spec=WebSocket)
+    other.accept = AsyncMock()
+    other.send_bytes = AsyncMock()
+    await manager.connect(mock_websocket, "room")
+    await manager.connect(other, "room")
+    await manager.broadcast_to_session("room", b"hello", exclude=mock_websocket)
+    other.send_bytes.assert_called_once_with(b"hello")
+    mock_websocket.send_bytes.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_session_encodes_str(manager, mock_websocket):
+    await manager.connect(mock_websocket, "room")
+    await manager.broadcast_to_session("room", "text message", exclude=None)
+    mock_websocket.send_bytes.assert_called_once_with(b"text message")
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_nonexistent_session_no_op(manager):
+    await manager.broadcast_to_session("missing", b"data")
+    # No exception, no sends
+    assert "missing" not in manager._sessions
+
+
+@pytest.mark.asyncio
+async def test_broadcast_send_bytes_exception_disconnects_dead_client(manager, mock_websocket):
+    dead_ws = MagicMock(spec=WebSocket)
+    dead_ws.accept = AsyncMock()
+    dead_ws.send_bytes = AsyncMock(side_effect=Exception("connection closed"))
+    await manager.connect(mock_websocket, "room")
+    await manager.connect(dead_ws, "room")
+    await manager.broadcast_to_session("room", b"msg", exclude=None)
+    mock_websocket.send_bytes.assert_called_once_with(b"msg")
+    dead_ws.send_bytes.assert_called_once()
+    # Dead client should be removed from session
+    assert dead_ws not in manager._sessions.get("room", [])


### PR DESCRIPTION
## Summary
Implements backend unit and integration tests (issue #9). 100% statement coverage on application code.

## Test suite
- **Unit:** `llm_client`, `agent_state`, `story_agent` (safety, LLM fallback, RAG node), `lore_tools`, `ws_manager`
- **Integration:** `GET /`, `GET /api/health`, `POST /api/generate-story`, WebSocket `/ws/story/{session_id}`

## Coverage
- pytest-cov with `.coveragerc`: omit `tests/` and `scripts/`, fail under 100%
- 48 tests, all passing; 100% coverage on `agent_state`, `llm_client`, `lore_tools`, `main`, `story_agent`, `ws_manager`

## Other
- README: backend tests section (run with `pytest tests/ -v`)
- .gitignore: `.coverage.*` for coverage data files
